### PR TITLE
Ask for a specific version of warp

### DIFF
--- a/generator/release.nix
+++ b/generator/release.nix
@@ -1,5 +1,8 @@
 with import <nixpkgs> {};
-let myHaskellPackages = pkgs.haskellPackages.override {
-      overrides = self: super: with pkgs.haskell.lib;
-        { hakyll = doJailbreak (appendConfigureFlag super.hakyll "-f previewServer"); };
-    }; in myHaskellPackages.callPackage ./default.nix {}
+let
+  myHaskellPackages = pkgs.haskellPackages.override {
+    overrides = self: super: with pkgs.haskell.lib; {
+      warp = doJailbreak (super.callHackage "warp" "3.2.28" {});
+    };
+  };
+in myHaskellPackages.callPackage ./default.nix {}


### PR DESCRIPTION
I asked for a specific version of warp that's compatible with hakyll's bounds, because that was easier than preparing a patch to hakyll's cabal file.

warp then complained about a http2 dependency, and it was easier to jailbreak warp than try to LARP cabal's resolver. Rebuilds fewer packages, too.